### PR TITLE
Fix selector optimization bug.

### DIFF
--- a/src/select.js
+++ b/src/select.js
@@ -19,11 +19,12 @@ import { getCommonAncestor, getCommonProperties } from './common'
  * @return {string}              - [description]
  */
 export function getSingleSelector (element, options = {}) {
-
+  // 3 refers to - Node.TEXT_NODE type
   if (element.nodeType === 3) {
     element = element.parentNode
   }
 
+  // 1 refers to - Node.ELEMENT_NODE type
   if (element.nodeType !== 1) {
     throw new Error(`Invalid input - only HTMLElements or representations of them are supported! (not "${typeof element}")`)
   }
@@ -39,11 +40,20 @@ export function getSingleSelector (element, options = {}) {
   //   optimized: ${optimized}
   // `)
 
+  let selectorTarget = global.document.querySelector(selector);
+  let optimizedSelectorTarget = global.document.querySelector(optimized);
+
   if (globalModified) {
     delete global.document
   }
 
-  return optimized
+  if (selectorTarget != optimizedSelectorTarget) {
+    console.log('Error at selector optimization. Returning the raw selector.');
+
+    return selector;
+  }
+
+  return optimized;
 }
 
 /**


### PR DESCRIPTION
In some rare cases the `optimize` function which optimises the generated selector, returns a selector string that no longer refers to the target element.

This provides a correctness check and returns the original selector value in such cases.